### PR TITLE
Updating travis base image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ services:
   - docker
 
 env:
-  - FEDORA=27
   - FEDORA=28
+  - FEDORA=29
 
 install:
   - docker pull registry.fedoraproject.org/fedora:$FEDORA


### PR DESCRIPTION
Tomcatjss 7.3.x requires `jss >= 4.5.x` which is available only in f28 or f29.

f27 has already reached its EOL.

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`