### PR TITLE
JSSContext - SSLEngine support

### DIFF
--- a/tomcat-8.5/src/org/dogtagpki/tomcat/JSSContext.java
+++ b/tomcat-8.5/src/org/dogtagpki/tomcat/JSSContext.java
@@ -1,0 +1,99 @@
+package org.dogtagpki.tomcat;
+
+import java.security.Provider;
+import java.security.KeyManagementException;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.util.List;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManager;
+
+import org.apache.tomcat.util.net.SSLContext;
+
+import org.mozilla.jss.provider.javax.crypto.JSSKeyManager;
+import org.mozilla.jss.provider.javax.crypto.JSSTrustManager;
+import org.mozilla.jss.ssl.javax.JSSEngine;
+import org.mozilla.jss.ssl.javax.JSSParameters;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JSSContext implements org.apache.tomcat.util.net.SSLContext {
+    public static Logger logger = LoggerFactory.getLogger(JSSContext.class);
+
+    private javax.net.ssl.SSLContext ctx;
+    private String alias;
+
+    private JSSKeyManager jkm;
+    private JSSTrustManager jtm;
+
+    public JSSContext(String alias) {
+        logger.debug("JSSContext(" + alias + ")");
+        this.alias = alias;
+
+        /* These KeyManagers and TrustManagers aren't used with the SSLEngine;
+         * they're only used to implement certain function calls below. */
+        jkm = new JSSKeyManager();
+        jtm = new JSSTrustManager();
+    }
+
+    public void init(KeyManager[] kms, TrustManager[] tms, SecureRandom sr) throws KeyManagementException {
+        logger.debug("JSSContext.init(...)");
+
+        try {
+            ctx = javax.net.ssl.SSLContext.getInstance("TLS", "Mozilla-JSS");
+            ctx.init(kms, tms, sr);
+        } catch (Exception e) {
+            throw new KeyManagementException(e.getMessage(), e);
+        }
+    }
+
+    public javax.net.ssl.SSLEngine createSSLEngine() {
+        logger.debug("JSSContext.createSSLEngine()");
+
+        JSSEngine eng = (JSSEngine) ctx.createSSLEngine();
+        eng.setCertFromAlias(alias);
+        return eng;
+    }
+
+    public javax.net.ssl.SSLSessionContext getServerSessionContext() {
+        logger.debug("JSSContext.getServerSessionContext()");
+        return ctx.getServerSessionContext();
+    }
+
+    public javax.net.ssl.SSLServerSocketFactory getServerSocketFactory() {
+        logger.debug("JSSContext.getServerSocketFactory()");
+        return ctx.getServerSocketFactory();
+    }
+
+    public javax.net.ssl.SSLParameters getSupportedSSLParameters() {
+        logger.debug("JSSContext.getSupportedSSLParameters()");
+        return ctx.getSupportedSSLParameters();
+    }
+
+    public java.security.cert.X509Certificate[] getCertificateChain(java.lang.String alias) {
+        logger.debug("JSSContext.getCertificateChain(" + alias + ")");
+
+        try {
+            return jkm.getCertificateChain(alias);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+        logger.debug("JSSContext.getAcceptedIssuers()");
+
+        try {
+            return jtm.getAcceptedIssuers();
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    public void destroy() {
+        logger.debug("JSSContext.destory()");
+    }
+}

--- a/tomcat-8.5/src/org/dogtagpki/tomcat/JSSImplementation.java
+++ b/tomcat-8.5/src/org/dogtagpki/tomcat/JSSImplementation.java
@@ -19,19 +19,30 @@
 
 package org.dogtagpki.tomcat;
 
+import javax.net.ssl.SSLSession;
+
+import org.apache.tomcat.util.net.jsse.JSSESupport;
 import org.apache.tomcat.util.net.SSLHostConfig;
 import org.apache.tomcat.util.net.SSLHostConfigCertificate;
+import org.apache.tomcat.util.net.SSLImplementation;
+import org.apache.tomcat.util.net.SSLSupport;
 import org.apache.tomcat.util.net.SSLUtil;
-import org.apache.tomcat.util.net.jsse.JSSEImplementation;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class JSSImplementation extends JSSEImplementation {
+public class JSSImplementation extends SSLImplementation {
 
     public static Logger logger = LoggerFactory.getLogger(JSSUtil.class);
 
     public JSSImplementation() {
         logger.debug("JSSImplementation: instance created");
+    }
+
+    @Override
+    public SSLSupport getSSLSupport(SSLSession session) {
+        logger.debug("JSSImplementation.getSSLSupport()");
+        return new JSSESupport(session);
     }
 
     @Override
@@ -46,5 +57,11 @@ public class JSSImplementation extends JSSEImplementation {
         logger.debug("JSSImplementation: truststore provider: " + hostConfig.getTruststoreProvider());
 
         return new JSSUtil(cert);
+    }
+
+    @Override
+    public boolean isAlpnSupported() {
+        // NSS supports ALPN but JSS doesn't yet support ALPN.
+        return false;
     }
 }


### PR DESCRIPTION
~This is in combination with [jss-pr#150](https://github.com/dogtagpki/jss/pull/150) and [jss-pr#196](https://github.com/dogtagpki/jss/pull/196).~

Add support for `javax.net.ssl.SSLEngine`; this enables us to use NSS for TLS in Tomcat. 

This needs to be: 

 - [x] JSS is extended with required features.
 - [x] Cleaned up a little.
 - [ ] Tested thoroughly with `pki-ca` as well. 

----

This is the first set of changes that'll enable us to use SSLEngine in PKI. I'm not sure yet if this'll be the final solution though; I'm hoping to get SSLEngine to a point where we can use it directly from Tomcat without needing the TomcatJSS compatibility layer. 