### PR TITLE
SSLEngine - minor refactors and version bump

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -37,8 +37,8 @@
 
   <property name="Name" value="Tomcat JSS"/>
   <property name="name" value="tomcatjss"/>
-  <property name="version" value="7.3.0"/>
-  <property name="manifest-version" value="${version}"/>
+  <property name="version" value="7.5.0"/>
+  <property name="manifest-version" value="${version}-a1"/>
 
   <!--
     Set the properties that control various build options

--- a/tomcat-8.5/src/org/dogtagpki/tomcat/JSSUtil.java
+++ b/tomcat-8.5/src/org/dogtagpki/tomcat/JSSUtil.java
@@ -19,6 +19,7 @@
 
 package org.dogtagpki.tomcat;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.HashSet;
@@ -45,8 +46,8 @@ public class JSSUtil extends SSLUtilBase {
     public static Log logger = LogFactory.getLog(JSSUtil.class);
 
     private String keyAlias;
-    private String[] protocols;
-    private String[] ciphers;
+    private Set<String> protocols;
+    private Set<String> ciphers;
 
     public JSSUtil(SSLHostConfigCertificate cert) {
         super(cert);
@@ -54,9 +55,9 @@ public class JSSUtil extends SSLUtilBase {
         keyAlias = certificate.getCertificateKeyAlias();
         logger.debug("JSSUtil: instance created");
 
-        JSSEngine eng = new JSSEngineReferenceImpl();
-        protocols = eng.getSupportedProtocols();
-        ciphers = eng.getSupportedCipherSuites();
+        JSSEngineReferenceImpl eng = new JSSEngineReferenceImpl();
+        protocols = new HashSet<String>(Arrays.asList(eng.getSupportedProtocols()));
+        ciphers = new HashSet<String>(Arrays.asList(eng.getSupportedCipherSuites()));
     }
 
     @Override

--- a/tomcat-8.5/src/org/dogtagpki/tomcat/JSSUtil.java
+++ b/tomcat-8.5/src/org/dogtagpki/tomcat/JSSUtil.java
@@ -39,17 +39,24 @@ import org.mozilla.jss.provider.javax.crypto.JSSKeyManager;
 import org.mozilla.jss.provider.javax.crypto.JSSNativeTrustManager;
 import org.mozilla.jss.ssl.SSLCipher;
 import org.mozilla.jss.ssl.SSLVersion;
+import org.mozilla.jss.ssl.javax.JSSEngineReferenceImpl;
 
 public class JSSUtil extends SSLUtilBase {
     public static Log logger = LogFactory.getLog(JSSUtil.class);
 
     private String keyAlias;
+    private String[] protocols;
+    private String[] ciphers;
 
     public JSSUtil(SSLHostConfigCertificate cert) {
         super(cert);
 
         keyAlias = certificate.getCertificateKeyAlias();
         logger.debug("JSSUtil: instance created");
+
+        JSSEngine eng = new JSSEngineReferenceImpl();
+        protocols = eng.getSupportedProtocols();
+        ciphers = eng.getSupportedCipherSuites();
     }
 
     @Override
@@ -86,24 +93,12 @@ public class JSSUtil extends SSLUtilBase {
     protected Set<String> getImplementedProtocols() {
         logger.debug("JSSUtil: getImplementedProtocols()");
 
-        Set<String> protocols = new HashSet<String>();
-        for (SSLVersion ver : Policy.TLS_VERSION_RANGE.getAllInRange()) {
-            protocols.add(ver.jdkAlias());
-        }
-
         return protocols;
     }
 
     @Override
     protected Set<String> getImplementedCiphers() {
         logger.debug("JSSUtil: getImplementedCiphers()");
-
-        Set<String> ciphers = new HashSet<String>();
-        for (SSLCipher cipher : SSLCipher.values()) {
-            if (cipher.isSupported()) {
-                ciphers.add(cipher.name());
-            }
-        }
 
         return ciphers;
     }

--- a/tomcatjss.spec
+++ b/tomcatjss.spec
@@ -57,7 +57,7 @@ BuildRequires:    slf4j-jdk14
 %if 0%{?rhel} && 0%{?rhel} <= 7
 BuildRequires:    jss >= 4.4.0-7
 %else
-BuildRequires:    jss >= 4.6.0
+BuildRequires:    jss >= 4.7.0
 %endif
 
 # Tomcat
@@ -104,7 +104,7 @@ Requires:         slf4j-jdk14
 %if 0%{?rhel} && 0%{?rhel} <= 7
 Requires:         jss >= 4.4.0-7
 %else
-Requires:         jss >= 4.6.0
+Requires:         jss >= 4.7.0
 %endif
 
 # Tomcat

--- a/tomcatjss.spec
+++ b/tomcatjss.spec
@@ -7,9 +7,9 @@ URL:              http://www.dogtagpki.org/wiki/TomcatJSS
 License:          LGPLv2+
 BuildArch:        noarch
 
-Version:          7.4.1
-Release:          2%{?_timestamp}%{?_commit_id}%{?dist}
-# global           _phase -a1
+Version:          7.5.0
+Release:          1%{?_timestamp}%{?_commit_id}%{?dist}
+%global           _phase -a1
 
 # To generate the source tarball:
 # $ git clone https://github.com/dogtagpki/tomcatjss.git


### PR DESCRIPTION
 - Bumps JSS version to v4.7.0, which will feature SSLEngine
 - Refactors how supported cipher suites are determined. 
 - Bumps TomcatJSS version to v7.5.0