### PR TITLE
Make protocols, ciphers unmodifiable

### DIFF
--- a/tomcat-8.5/src/org/dogtagpki/tomcat/JSSUtil.java
+++ b/tomcat-8.5/src/org/dogtagpki/tomcat/JSSUtil.java
@@ -20,6 +20,7 @@
 package org.dogtagpki.tomcat;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.HashSet;
@@ -46,19 +47,22 @@ public class JSSUtil extends SSLUtilBase {
     public static Log logger = LogFactory.getLog(JSSUtil.class);
 
     private String keyAlias;
-    private Set<String> protocols;
-    private Set<String> ciphers;
+
+    private JSSEngineReferenceImpl engine = new JSSEngineReferenceImpl();
+    private Set<String> protocols = Collections.unmodifiableSet(
+        new HashSet<String>(Arrays.asList(engine.getSupportedProtocols()))
+    );
+    private Set<String> ciphers = Collections.unmodifiableSet(
+        new HashSet<String>(Arrays.asList(engine.getSupportedCipherSuites()))
+    );
 
     public JSSUtil(SSLHostConfigCertificate cert) {
         super(cert);
 
         keyAlias = certificate.getCertificateKeyAlias();
         logger.debug("JSSUtil: instance created");
-
-        JSSEngineReferenceImpl eng = new JSSEngineReferenceImpl();
-        protocols = new HashSet<String>(Arrays.asList(eng.getSupportedProtocols()));
-        ciphers = new HashSet<String>(Arrays.asList(eng.getSupportedCipherSuites()));
     }
+
 
     @Override
     public KeyManager[] getKeyManagers() throws Exception {


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

----

When attempting to re-enable copr (dogtagpki/pki#396), CI discovered an error in #15:

```

2020-04-30T14:56:25.4858407Z Apr 30 14:55:26 master.pki.test server[1396]: SEVERE: Failed to initialize component [Connector[org.dogtagpki.tomcat.Http11NioProtocol-8443]]
2020-04-30T14:56:25.4858676Z Apr 30 14:55:26 master.pki.test server[1396]: org.apache.catalina.LifecycleException: Protocol handler initialization failed
2020-04-30T14:56:25.4858899Z Apr 30 14:55:26 master.pki.test server[1396]:         at org.apache.catalina.connector.Connector.initInternal(Connector.java:1013)
2020-04-30T14:56:25.4859122Z Apr 30 14:55:26 master.pki.test server[1396]:         at org.apache.catalina.util.LifecycleBase.init(LifecycleBase.java:136)
2020-04-30T14:56:25.4859341Z Apr 30 14:55:26 master.pki.test server[1396]:         at org.apache.catalina.core.StandardService.initInternal(StandardService.java:533)
2020-04-30T14:56:25.4859565Z Apr 30 14:55:26 master.pki.test server[1396]:         at org.apache.catalina.util.LifecycleBase.init(LifecycleBase.java:136)
2020-04-30T14:56:25.4859783Z Apr 30 14:55:26 master.pki.test server[1396]:         at org.apache.catalina.core.StandardServer.initInternal(StandardServer.java:1057)
2020-04-30T14:56:25.4860003Z Apr 30 14:55:26 master.pki.test server[1396]:         at org.apache.catalina.util.LifecycleBase.init(LifecycleBase.java:136)
2020-04-30T14:56:25.4860399Z Apr 30 14:55:26 master.pki.test server[1396]:         at org.apache.catalina.startup.Catalina.load(Catalina.java:584)
2020-04-30T14:56:25.4860622Z Apr 30 14:55:26 master.pki.test server[1396]:         at org.apache.catalina.startup.Catalina.load(Catalina.java:607)
2020-04-30T14:56:25.4862585Z Apr 30 14:55:26 master.pki.test server[1396]:         at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
2020-04-30T14:56:25.4863029Z Apr 30 14:55:26 master.pki.test server[1396]:         at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
2020-04-30T14:56:25.4864220Z Apr 30 14:55:26 master.pki.test server[1396]:         at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2020-04-30T14:56:25.4864415Z Apr 30 14:55:26 master.pki.test server[1396]:         at java.lang.reflect.Method.invoke(Method.java:498)
2020-04-30T14:56:25.4864546Z Apr 30 14:55:26 master.pki.test server[1396]:         at org.apache.catalina.startup.Bootstrap.load(Bootstrap.java:303)
2020-04-30T14:56:25.4864660Z Apr 30 14:55:26 master.pki.test server[1396]:         at org.apache.catalina.startup.Bootstrap.main(Bootstrap.java:473)
2020-04-30T14:56:25.4864745Z Apr 30 14:55:26 master.pki.test server[1396]: Caused by: java.lang.NullPointerException
2020-04-30T14:56:25.4864862Z Apr 30 14:55:26 master.pki.test server[1396]:         at org.apache.tomcat.util.net.SSLUtilBase.<init>(SSLUtilBase.java:96)
2020-04-30T14:56:25.4864977Z Apr 30 14:55:26 master.pki.test server[1396]:         at org.apache.tomcat.util.net.SSLUtilBase.<init>(SSLUtilBase.java:83)
2020-04-30T14:56:25.4865090Z Apr 30 14:55:26 master.pki.test server[1396]:         at org.dogtagpki.tomcat.JSSUtil.<init>(JSSUtil.java:53)
2020-04-30T14:56:25.4865205Z Apr 30 14:55:26 master.pki.test server[1396]:         at org.dogtagpki.tomcat.JSSImplementation.getSSLUtil(JSSImplementation.java:59)
2020-04-30T14:56:25.4865309Z Apr 30 14:55:26 master.pki.test server[1396]:         at org.apache.tomcat.util.net.AbstractJsseEndpoint.createSSLContext(AbstractJsseEndpoint.java:88)
2020-04-30T14:56:25.4865430Z Apr 30 14:55:26 master.pki.test server[1396]:         at org.apache.tomcat.util.net.AbstractJsseEndpoint.initialiseSsl(AbstractJsseEndpoint.java:71)
2020-04-30T14:56:25.4865553Z Apr 30 14:55:26 master.pki.test server[1396]:         at org.apache.tomcat.util.net.NioEndpoint.bind(NioEndpoint.java:217)
2020-04-30T14:56:25.4865666Z Apr 30 14:55:26 master.pki.test server[1396]:         at org.apache.tomcat.util.net.AbstractEndpoint.bindWithCleanup(AbstractEndpoint.java:1141)
2020-04-30T14:56:25.4865777Z Apr 30 14:55:26 master.pki.test server[1396]:         at org.apache.tomcat.util.net.AbstractEndpoint.init(AbstractEndpoint.java:1154)
2020-04-30T14:56:25.4865889Z Apr 30 14:55:26 master.pki.test server[1396]:         at org.apache.coyote.AbstractProtocol.init(AbstractProtocol.java:581)
2020-04-30T14:56:25.4866007Z Apr 30 14:55:26 master.pki.test server[1396]:         at org.apache.coyote.http11.AbstractHttp11Protocol.init(AbstractHttp11Protocol.java:74)
2020-04-30T14:56:25.4866127Z Apr 30 14:55:26 master.pki.test server[1396]:         at org.apache.catalina.connector.Connector.initInternal(Connector.java:1010)
```

In particular there's a dependency:

 - `JSSUtil.<init>()` calls `super(...)`
 - `SSLUtilBase` calls `getImplementedProtocols(...)`,
 - But because `JSSUtil.<init>()` hasn't finished running `protocols` and `ciphers` are `null`.
 - Causing the NPE above.

Move `protocols` and `ciphers` to a static initialization block and switch to the unmodifiable set as suggested by @edewata  on IRC.