### PR TITLE
Make protocols, cipher suites static

### DIFF
--- a/tomcat-8.5/src/org/dogtagpki/tomcat/JSSUtil.java
+++ b/tomcat-8.5/src/org/dogtagpki/tomcat/JSSUtil.java
@@ -48,11 +48,11 @@ public class JSSUtil extends SSLUtilBase {
 
     private String keyAlias;
 
-    private JSSEngineReferenceImpl engine = new JSSEngineReferenceImpl();
-    private Set<String> protocols = Collections.unmodifiableSet(
+    private static JSSEngineReferenceImpl engine = new JSSEngineReferenceImpl();
+    private static Set<String> protocols = Collections.unmodifiableSet(
         new HashSet<String>(Arrays.asList(engine.getSupportedProtocols()))
     );
-    private Set<String> ciphers = Collections.unmodifiableSet(
+    private static Set<String> ciphers = Collections.unmodifiableSet(
         new HashSet<String>(Arrays.asList(engine.getSupportedCipherSuites()))
     );
 


### PR DESCRIPTION
Because of the way initialization happens in Java, the previous method
wouldn't work because they got initialized AFTER the super's constructor
had executed. Making them static ensures they get executed prior to
super's constructor executing.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`