### PR TITLE
Make TomcatJSS use both SunJSSE and Mozilla-JSS

### DIFF
--- a/tomcat-8.5/src/org/dogtagpki/tomcat/JSSContext.java
+++ b/tomcat-8.5/src/org/dogtagpki/tomcat/JSSContext.java
@@ -12,6 +12,7 @@ import javax.net.ssl.TrustManager;
 
 import org.apache.tomcat.util.net.SSLContext;
 
+import org.mozilla.jss.JSSProvider;
 import org.mozilla.jss.provider.javax.crypto.JSSKeyManager;
 import org.mozilla.jss.provider.javax.crypto.JSSTrustManager;
 import org.mozilla.jss.ssl.javax.JSSEngine;
@@ -43,7 +44,12 @@ public class JSSContext implements org.apache.tomcat.util.net.SSLContext {
         logger.debug("JSSContext.init(...)");
 
         try {
-            ctx = javax.net.ssl.SSLContext.getInstance("TLS", "Mozilla-JSS");
+            String provider = "SunJSSE";
+            if (JSSProvider.ENABLE_JSSENGINE) {
+                provider = "Mozilla-JSS";
+            }
+
+            ctx = javax.net.ssl.SSLContext.getInstance("TLS", provider);
             ctx.init(kms, tms, sr);
         } catch (Exception e) {
             throw new KeyManagementException(e.getMessage(), e);

--- a/tomcat-8.5/src/org/dogtagpki/tomcat/JSSUtil.java
+++ b/tomcat-8.5/src/org/dogtagpki/tomcat/JSSUtil.java
@@ -39,9 +39,12 @@ import org.apache.tomcat.util.net.SSLUtilBase;
 import org.mozilla.jss.crypto.Policy;
 import org.mozilla.jss.provider.javax.crypto.JSSKeyManager;
 import org.mozilla.jss.provider.javax.crypto.JSSNativeTrustManager;
+import org.mozilla.jss.provider.javax.crypto.JSSTrustManager;
 import org.mozilla.jss.ssl.SSLCipher;
 import org.mozilla.jss.ssl.SSLVersion;
 import org.mozilla.jss.ssl.javax.JSSEngineReferenceImpl;
+
+import org.mozilla.jss.JSSProvider;
 
 public class JSSUtil extends SSLUtilBase {
     public static Log logger = LogFactory.getLog(JSSUtil.class);
@@ -73,6 +76,9 @@ public class JSSUtil extends SSLUtilBase {
     @Override
     public TrustManager[] getTrustManagers() throws Exception {
         logger.debug("JSSUtil: getTrustManagers()");
+        if (!JSSProvider.ENABLE_JSSENGINE) {
+            return new TrustManager[] { new JSSTrustManager() };
+        }
         return new TrustManager[] { new JSSNativeTrustManager() };
     }
 


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

---

Since JSS now includes SSLEngine behind a gating flag, let TomcatJSS return appropriate configuration depending on whether or not SSLEngine is enabled. 