### PR TITLE
Fix Cipher, Protocol list for JSSE SSLEngines

### DIFF
--- a/tomcat-8.5/src/org/dogtagpki/tomcat/JSSContext.java
+++ b/tomcat-8.5/src/org/dogtagpki/tomcat/JSSContext.java
@@ -61,7 +61,7 @@ public class JSSContext implements org.apache.tomcat.util.net.SSLContext {
         javax.net.ssl.SSLEngine eng = ctx.createSSLEngine();
 
         if (eng instanceof JSSEngine) {
-            JSSEngine j_eng = (JSSEngine) ctx.createSSLEngine();
+            JSSEngine j_eng = (JSSEngine) eng;
             j_eng.setCertFromAlias(alias);
         }
 


### PR DESCRIPTION
@edewata -- This mirrors the behavior of the SunJSSE adapter for Tomcat. This makes it a list initialized just-in-time and removes `static`. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`