### PR TITLE
 Fix Bug 2001169 - Audit event 'ACCESS_SESSION_ESTABLISH' is not gene…

### DIFF
--- a/tomcat-9.0/src/main/java/org/dogtagpki/tomcat/JSSContext.java
+++ b/tomcat-9.0/src/main/java/org/dogtagpki/tomcat/JSSContext.java
@@ -1,8 +1,10 @@
 package org.dogtagpki.tomcat;
 
+import org.apache.tomcat.util.net.jss.TomcatJSS;
 import java.security.KeyManagementException;
 import java.security.SecureRandom;
-
+import java.util.Collection;
+import java.util.EventListener;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManager;
@@ -61,9 +63,14 @@ public class JSSContext implements org.apache.tomcat.util.net.SSLContext {
         logger.debug("JSSContext.createSSLEngine()");
         javax.net.ssl.SSLEngine eng = ctx.createSSLEngine();
 
+	TomcatJSS instance = TomcatJSS.getInstance();
+
         if (eng instanceof JSSEngine) {
             JSSEngine j_eng = (JSSEngine) eng;
             j_eng.setCertFromAlias(alias);
+	    if(instance != null) {
+	        j_eng.setListeners(instance.getSocketListeners());
+	    }
         }
 
         return eng;


### PR DESCRIPTION
…rating for PKI instances acting as Server [10.2.1]

    This fix allows us to actually see ssl connection events in the audit log from the pki /server perspective.
    This fill will also require support bug fixes for both jss and pki.