### PR TITLE
" Fix Bug 2001169 - Audit event 'ACCESS_SESSION_ESTABLISH' is not gene…

### DIFF
--- a/tomcat-9.0/src/main/java/org/dogtagpki/tomcat/JSSContext.java
+++ b/tomcat-9.0/src/main/java/org/dogtagpki/tomcat/JSSContext.java
@@ -70,9 +70,9 @@ public class JSSContext implements org.apache.tomcat.util.net.SSLContext {
         if (eng instanceof JSSEngine) {
             JSSEngine j_eng = (JSSEngine) eng;
             j_eng.setCertFromAlias(alias);
-	    if(instance != null) {
-	        j_eng.setListeners(instance.getSocketListeners());
-	    }
+            if(instance != null) {
+                j_eng.setListeners(instance.getSocketListeners());
+            }
         }
 
         return eng;

--- a/tomcat-9.0/src/main/java/org/dogtagpki/tomcat/JSSContext.java
+++ b/tomcat-9.0/src/main/java/org/dogtagpki/tomcat/JSSContext.java
@@ -1,8 +1,10 @@
 package org.dogtagpki.tomcat;
 
+import org.apache.tomcat.util.net.jss.TomcatJSS;
 import java.security.KeyManagementException;
 import java.security.SecureRandom;
-
+import java.util.Collection;
+import java.util.EventListener;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManager;
@@ -63,9 +65,14 @@ public class JSSContext implements org.apache.tomcat.util.net.SSLContext {
         logger.debug("JSSContext.createSSLEngine()");
         javax.net.ssl.SSLEngine eng = ctx.createSSLEngine();
 
+	TomcatJSS instance = TomcatJSS.getInstance();
+
         if (eng instanceof JSSEngine) {
             JSSEngine j_eng = (JSSEngine) eng;
             j_eng.setCertFromAlias(alias);
+	    if(instance != null) {
+	        j_eng.setListeners(instance.getSocketListeners());
+	    }
         }
 
         return eng;


### PR DESCRIPTION
…rating for PKI instances acting as Server [10.2.1] (#40)

This fix allows us to actually see ssl connection events in the audit log from the pki /server perspective.
    This fill will also require support bug fixes for both jss and pki."

This was a change made by @jmagne to fix bug: 2001169 for RHCS 10.2.1, Originally he only made the change on the `v7.7` branch but it needs to go to master as well. 

Tested locally by building and installing JSS, tomcatjss, and pki and observed the AUDIT logs:
```
0.https-jsse-nio-8443-exec-15 - [05/Nov/2021:15:31:17 GMT] [14] [6] [AuditEvent=ACCESS_SESSION_ESTABLISH][ClientIP=--][ServerIP=--][SubjectID=--][Outcome=Success] access session establish success
0.https-jsse-nio-8443-exec-16 - [05/Nov/2021:15:31:17 GMT] [14] [6] [AuditEvent=ACCESS_SESSION_TERMINATED][ClientIP=--][ServerIP=--][SubjectID=--][Outcome=Success][Info=serverAlertReceived: CLOSE_NOTIFY] access session terminated
```

This PR is dependent on JSS PR: https://github.com/dogtagpki/jss/pull/822 