### PR TITLE
Remove RPM dependency in build.sh

### DIFF
--- a/docs/changes/v8.1.0/Development-Changes.adoc
+++ b/docs/changes/v8.1.0/Development-Changes.adoc
@@ -1,0 +1,8 @@
+= Development Changes =
+
+== Build Changes ==
+
+By default the `./build.sh` will only create the JAR file instead of the RPM package.
+The JAR file can be installed on the system using `./build.sh install`.
+
+To build the RPM package, run `./build.sh rpm`.

--- a/docs/changes/v8.1.0/Packaging-Changes.adoc
+++ b/docs/changes/v8.1.0/Packaging-Changes.adoc
@@ -1,0 +1,10 @@
+= Packaging Changes =
+
+== Java Dependency Changes ==
+
+TomcatJSS will now require OpenJDK 17.
+
+== Java Archive Changes ==
+
+The `/usr/share/java/tomcatjss-<version>.jar` has been removed.
+Use `/usr/share/java/tomcatjss.jar` instead.

--- a/tomcatjss.spec
+++ b/tomcatjss.spec
@@ -9,9 +9,9 @@ BuildArch:        noarch
 
 # For development (i.e. unsupported) releases, use x.y.z-0.n.<phase>.
 # For official (i.e. supported) releases, use x.y.z-r where r >=1.
-Version:          8.0.0
-Release:          1%{?_timestamp}%{?_commit_id}%{?dist}
-#global           _phase -alpha1
+Version:          8.1.0
+Release:          0.1%{?_timestamp}%{?_commit_id}%{?dist}
+%global           _phase -alpha1
 
 # To generate the source tarball:
 # $ git clone https://github.com/dogtagpki/tomcatjss.git

--- a/tomcatjss.spec
+++ b/tomcatjss.spec
@@ -114,28 +114,24 @@ Services (NSS).
 %build
 ################################################################################
 
-# get Tomcat <major>.<minor> version number
-tomcat_version=`/usr/sbin/tomcat version | sed -n 's/Server number: *\([0-9]\+\.[0-9]\+\).*/\1/p'`
-app_server=tomcat-$tomcat_version
-
-ant -f build.xml \
+./build.sh \
     %{?_verbose:-v} \
-    -Dversion=%{version} \
-    -Djnidir=%{_jnidir} \
-    -Dsrc.dir=$app_server \
-    -Dbuild.dir=%{_vpath_builddir} \
-    compile package
+    --work-dir=%{_vpath_builddir} \
+    --version=%{version} \
+    --jni-dir=%{_jnidir} \
+    dist
 
 ################################################################################
 %install
 ################################################################################
 
-ant -f build.xml \
+./build.sh \
     %{?_verbose:-v} \
-    -Dversion=%{version} \
-    -Dbuild.dir=%{_vpath_builddir} \
-    -Dinstall.doc.dir=%{buildroot}%{_docdir} \
-    -Dinstall.jar.dir=%{buildroot}%{_javadir} \
+    --work-dir=%{_vpath_builddir} \
+    --version=%{version} \
+    --java-dir=%{_javadir} \
+    --doc-dir=%{_docdir} \
+    --install-dir=%{buildroot} \
     install
 
 ################################################################################


### PR DESCRIPTION
The `build.sh` has been modified to call `ant` directly instead of `rpmbuild` such that it can be used on platforms that do not
use RPM. The option to build RPM packages is still available.

The `tomcatjss.spec` has been modified to call `build.sh` instead of `ant`. The version number has also been updated to `8.1.0-alpha1`.

Docs:
* https://github.com/edewata/tomcatjss/blob/build/docs/changes/v8.1.0/Development-Changes.adoc
* https://github.com/edewata/tomcatjss/blob/build/docs/changes/v8.1.0/Packaging-Changes.adoc