### PR TITLE
Add Maven project

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -1,0 +1,63 @@
+name: Build Tests
+
+on: [push, pull_request]
+
+jobs:
+  init:
+    name: Initializing Workflow
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.init.outputs.matrix }}
+      repo: ${{ steps.init.outputs.repo }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Initialize workflow
+        id: init
+        env:
+          BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
+          BASE64_REPO: ${{ secrets.BASE64_REPO }}
+        run: |
+          tests/bin/init-workflow.sh
+
+  build-test:
+    name: Build Test
+    needs: init
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    container: fedora:${{ matrix.os }}
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: |
+        dnf install -y dnf-plugins-core maven
+        dnf copr enable -y ${{ needs.init.outputs.repo }}
+        dnf builddep -y --spec tomcatjss.spec
+
+    - name: Build Tomcat JSS with Ant
+      run: |
+        ./build.sh
+
+    - name: Install JSS into Maven repo
+      run: |
+        mvn install:install-file \
+            -Dfile=/usr/lib/java/jss.jar \
+            -DgroupId=org.dogtagpki \
+            -DartifactId=jss \
+            -Dversion=5.3.0-SNAPSHOT \
+            -Dpackaging=jar \
+            -DgeneratePom=true
+
+    - name: Build Tomcat JSS with Maven
+      run: |
+        mvn package
+
+    - name: Compare tomcatjss.jar
+      run: |
+        jar tvf ~/build/tomcatjss/jars/tomcatjss.jar | awk '{print $8;}' | sort | tee ant.out
+        jar tvf main/target/tomcatjss-main-8.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort > maven.out
+        diff ant.out maven.out

--- a/build.sh
+++ b/build.sh
@@ -319,7 +319,7 @@ if [ "$BUILD_TARGET" = "dist" ] ; then
 
     echo
     echo "Build artifacts:"
-    echo "- Java archive: $WORK_DIR/build/jars/tomcatjss.jar"
+    echo "- Java archive: $WORK_DIR/jars/tomcatjss.jar"
     echo
     echo "To install the build: $0 install"
     echo "To create RPM packages: $0 rpm"

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.dogtagpki</groupId>
+    <artifactId>tomcatjss-core</artifactId>
+    <version>8.3.0-SNAPSHOT</version>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.32</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-catalina</artifactId>
+            <version>9.0.50</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.dogtagpki</groupId>
+            <artifactId>jss</artifactId>
+            <version>5.3.0-SNAPSHOT</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>17</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.dogtagpki</groupId>
+    <artifactId>tomcatjss-main</artifactId>
+    <version>8.3.0-SNAPSHOT</version>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.dogtagpki</groupId>
+            <artifactId>tomcatjss-core</artifactId>
+            <version>8.3.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.dogtagpki</groupId>
+            <artifactId>tomcatjss-tomcat-9.0</artifactId>
+            <version>8.3.0-SNAPSHOT</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>1.2.2</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>org.slf4j:slf4j-api</exclude>
+                                    <exclude>org.apache.commons:commons-lang3</exclude>
+                                    <exclude>org.apache.tomcat:tomcat-catalina</exclude>
+                                    <exclude>org.apache.tomcat:tomcat-servlet-api</exclude>
+                                    <exclude>org.apache.tomcat:tomcat-jsp-api</exclude>
+                                    <exclude>org.apache.tomcat:tomcat-el-api</exclude>
+                                    <exclude>org.apache.tomcat:tomcat-juli</exclude>
+                                    <exclude>org.apache.tomcat:tomcat-annotations-api</exclude>
+                                    <exclude>org.apache.tomcat:tomcat-api</exclude>
+                                    <exclude>org.apache.tomcat:tomcat-jni</exclude>
+                                    <exclude>org.apache.tomcat:tomcat-coyote</exclude>
+                                    <exclude>org.apache.tomcat:tomcat-util</exclude>
+                                    <exclude>org.apache.tomcat:tomcat-util-scan</exclude>
+                                    <exclude>org.apache.tomcat:tomcat-jaspic-api</exclude>
+                                    <exclude>org.dogtagpki:jss</exclude>
+                                </excludes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.dogtagpki</groupId>
+    <artifactId>tomcatjss</artifactId>
+    <version>8.3.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>core</module>
+        <module>tomcat-9.0</module>
+        <module>main</module>
+    </modules>
+
+</project>

--- a/tomcat-9.0/pom.xml
+++ b/tomcat-9.0/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.dogtagpki</groupId>
+    <artifactId>tomcatjss-tomcat-9.0</artifactId>
+    <version>8.3.0-SNAPSHOT</version>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-catalina</artifactId>
+            <version>9.0.50</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.dogtagpki</groupId>
+            <artifactId>jss</artifactId>
+            <version>5.3.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.dogtagpki</groupId>
+            <artifactId>tomcatjss-core</artifactId>
+            <version>8.3.0-SNAPSHOT</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>17</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
New `pom.xml` files have been added to define the Maven project for Tomcat JSS. The project consists of a module that contains
the core classes, a module that contains Tomcat 9.0-specific classes, and another module that contains all of these classes.

A new CI test has been added to compare the original Ant build artifacts with the new Maven build artifacts.