### PR TITLE
Fix Sonarcloud error for maven config

### DIFF
--- a/.github/workflows/sonarcloud-pull.yml
+++ b/.github/workflows/sonarcloud-pull.yml
@@ -146,6 +146,8 @@ jobs:
           mkdir build
           docker cp pki:/usr/share/java/tomcatjss.jar build/
 
+      - name: Remove maven related file
+        run: rm -f pom.xml
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -86,6 +86,9 @@ jobs:
           mkdir build
           docker cp pki:/usr/share/java/tomcatjss.jar build/
 
+      - name: Remove maven related file
+        run: rm -f pom.xml
+
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:


### PR DESCRIPTION
The introduction of the pom.xml makes the sonarcloud scan fail so it is
removed for the scan