### PR TITLE
Consolidate build jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build Tomcat JSS
+
+on: [push, pull_request]
+
+jobs:
+  init:
+    name: Initialization
+    uses: ./.github/workflows/init.yml
+    secrets: inherit
+
+  build:
+    name: Building Tomcat JSS
+    needs: init
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build tomcatjss-runner image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+            BUILD_OPTS=--with-timestamp --with-commit-id
+          tags: tomcatjss-runner
+          target: tomcatjss-runner
+          cache-from: type=local,src=/tmp/.buildx-cache
+          outputs: type=docker,dest=tomcatjss-runner.tar
+
+      - name: Store tomcatjss-runner image
+        uses: actions/cache@v3
+        with:
+          key: tomcatjss-runner-${{ matrix.os }}-${{ github.sha }}
+          path: tomcatjss-runner.tar

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -8,36 +8,29 @@ jobs:
     secrets: inherit
 
   build:
-    name: Building TomcatJSS
+    name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build runner image
-        uses: docker/build-push-action@v2
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-            BUILD_OPTS=--with-timestamp --with-commit-id
-          tags: tomcatjss-runner
-          target: tomcatjss-runner
-          outputs: type=docker,dest=sonar-runner.tar
+          ref: ${{ github.ref }}
+          check-name: 'Building Tomcat JSS (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'push'
 
-      - name: Store runner image
-        uses: actions/cache@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          key: sonar-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: sonar-runner.tar
-
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Building Tomcat JSS (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'pull_request'
 
   sonarcloud:
     name: SonarCloud
@@ -52,15 +45,14 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
-
-      - name: Retrieve runner image
+      - name: Retrieve tomcatjss-runner image
         uses: actions/cache@v3
         with:
-          key: sonar-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: sonar-runner.tar
+          key: tomcatjss-runner-${{ matrix.os }}-${{ github.sha }}
+          path: tomcatjss-runner.tar
 
-      - name: Load runner image
-        run: docker load --input sonar-runner.tar
+      - name: Load tomcatjss-runner image
+        run: docker load --input tomcatjss-runner.tar
 
       - name: Run container
         run: |

--- a/.github/workflows/pki-tests.yml
+++ b/.github/workflows/pki-tests.yml
@@ -9,35 +9,29 @@ jobs:
     secrets: inherit
 
   build:
-    name: Building TomcatJSS
+    name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build runner image
-        uses: docker/build-push-action@v2
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-            BUILD_OPTS=--with-timestamp --with-commit-id
-          tags: tomcatjss-runner
-          target: tomcatjss-runner
-          outputs: type=docker,dest=tomcatjss-runner.tar
+          ref: ${{ github.ref }}
+          check-name: 'Building Tomcat JSS (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'push'
 
-      - name: Store runner image
-        uses: actions/cache@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          key: tomcatjss-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: tomcatjss-runner.tar
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Building Tomcat JSS (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'pull_request'
 
   # https://github.com/dogtagpki/pki/blob/master/docs/installation/server/Installing_Basic_PKI_Server.md
   ssl-test:
@@ -52,13 +46,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Retrieve runner image
+      - name: Retrieve tomcatjss-runner image
         uses: actions/cache@v3
         with:
-          key: tomcatjss-runner-${{ matrix.os }}-${{ github.run_id }}
+          key: tomcatjss-runner-${{ matrix.os }}-${{ github.sha }}
           path: tomcatjss-runner.tar
 
-      - name: Load runner image
+      - name: Load tomcatjss-runner image
         run: docker load --input tomcatjss-runner.tar
 
       - name: Run container
@@ -156,13 +150,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Retrieve runner image
+      - name: Retrieve tomcatjss-runner image
         uses: actions/cache@v3
         with:
-          key: tomcatjss-runner-${{ matrix.os }}-${{ github.run_id }}
+          key: tomcatjss-runner-${{ matrix.os }}-${{ github.sha }}
           path: tomcatjss-runner.tar
 
-      - name: Load runner image
+      - name: Load tomcatjss-runner image
         run: docker load --input tomcatjss-runner.tar
 
       - name: Run container


### PR DESCRIPTION
The build jobs in test workflows have been consolidated into `build.yml` such that the build will be created just once by the build workflow, and the test workflows will use the same build once it's completed.

https://github.com/lewagon/wait-on-check-action