### PR TITLE
Cache tomcatjss-deps and tomcatjss-builder-deps images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+tomcatjss-builder.tar
+tomcatjss-runner.tar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,55 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Cache Docker layers
+        id: cache-buildx
+        uses: actions/cache@v3
+        with:
+          key: buildx-${{ matrix.os }}-${{ hashFiles('tomcatjss.spec') }}
+          path: /tmp/.buildx-cache
+
+      - name: Build tomcatjss-deps image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: tomcatjss-deps
+          target: tomcatjss-deps
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+
+      - name: Build tomcatjss-builder-deps image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: tomcatjss-builder-deps
+          target: tomcatjss-builder-deps
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+
+      - name: Build tomcatjss-builder image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: tomcatjss-builder
+          target: tomcatjss-builder
+          cache-from: type=local,src=/tmp/.buildx-cache
+          outputs: type=docker,dest=tomcatjss-builder.tar
+
+      - name: Store tomcatjss-builder image
+        uses: actions/cache@v3
+        with:
+          key: tomcatjss-builder-${{ matrix.os }}-${{ github.sha }}
+          path: tomcatjss-builder.tar
+
       - name: Build tomcatjss-runner image
         uses: docker/build-push-action@v3
         with:


### PR DESCRIPTION
The build job has been modified to cache the runtime and build dependencies.