### PR TITLE
Add tomcatjss-dist image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 tomcatjss-builder.tar
+tomcatjss-dist.tar
 tomcatjss-runner.tar

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -27,11 +27,12 @@ jobs:
       env:
         COPR_REPO: ${{ needs.init.outputs.repo }}
 
-    - name: Install JSS packages from jss-builder
+    - name: Install JSS packages from jss-dist
       run: |
-        docker pull ghcr.io/dogtagpki/jss-builder:latest
-        docker create --name=jss-builder ghcr.io/dogtagpki/jss-builder:latest
-        docker cp jss-builder:/root/jss/build/RPMS /tmp/RPMS/
+        docker pull ghcr.io/dogtagpki/jss-dist:latest
+        docker create --name=jss-dist ghcr.io/dogtagpki/jss-dist:latest
+        docker cp jss-dist:/root/RPMS /tmp/RPMS/
+        docker rm -f jss-dist
         dnf localinstall -y /tmp/RPMS/*
 
     - name: Build Tomcat JSS with Ant

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,24 @@ jobs:
           key: tomcatjss-builder-${{ matrix.os }}-${{ github.sha }}
           path: tomcatjss-builder.tar
 
+      - name: Build tomcatjss-dist image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: tomcatjss-dist
+          target: tomcatjss-dist
+          cache-from: type=local,src=/tmp/.buildx-cache
+          outputs: type=docker,dest=tomcatjss-dist.tar
+
+      - name: Store tomcatjss-dist image
+        uses: actions/cache@v3
+        with:
+          key: tomcatjss-dist-${{ matrix.os }}-${{ github.sha }}
+          path: tomcatjss-dist.tar
+
       - name: Build tomcatjss-runner image
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,17 +29,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Retrieve tomcatjss-builder image
+      - name: Retrieve tomcatjss-dist image
         uses: actions/cache@v3
         with:
-          key: tomcatjss-builder-${{ matrix.os }}-${{ github.sha }}
-          path: tomcatjss-builder.tar
+          key: tomcatjss-dist-${{ matrix.os }}-${{ github.sha }}
+          path: tomcatjss-dist.tar
 
-      - name: Publish tomcatjss-builder image
+      - name: Publish tomcatjss-dist image
         run: |
-          docker load --input tomcatjss-builder.tar
-          docker tag tomcatjss-builder ghcr.io/${{ github.repository_owner }}/tomcatjss-builder:latest
-          docker push ghcr.io/${{ github.repository_owner }}/tomcatjss-builder:latest
+          docker load --input tomcatjss-dist.tar
+          docker tag tomcatjss-dist ghcr.io/${{ github.repository_owner }}/tomcatjss-dist:latest
+          docker push ghcr.io/${{ github.repository_owner }}/tomcatjss-dist:latest
 
       - name: Retrieve tomcatjss-runner image
         uses: actions/cache@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,8 @@ RUN dnf builddep -y --skip-unavailable --spec tomcatjss.spec
 ################################################################################
 FROM tomcatjss-builder-deps AS tomcatjss-builder
 
-# Import JSS packages from jss-builder
-COPY --from=ghcr.io/dogtagpki/jss-builder:latest /root/jss/build/RPMS /tmp/RPMS/
+# Import JSS packages
+COPY --from=ghcr.io/dogtagpki/jss-dist:latest /root/RPMS /tmp/RPMS/
 
 # Install build depencencies
 RUN dnf localinstall -y /tmp/RPMS/* \
@@ -62,13 +62,19 @@ COPY . /root/tomcatjss/
 RUN ./build.sh --work-dir=build rpm
 
 ################################################################################
-FROM tomcatjss-deps AS tomcatjss-runner
-
-# Import JSS packages from jss-builder
-COPY --from=ghcr.io/dogtagpki/jss-builder:latest /root/jss/build/RPMS /tmp/RPMS/
+FROM alpine:latest AS tomcatjss-dist
 
 # Import Tomcat JSS packages
-COPY --from=tomcatjss-builder /root/tomcatjss/build/RPMS /tmp/RPMS/
+COPY --from=tomcatjss-builder /root/tomcatjss/build/RPMS /root/RPMS/
+
+################################################################################
+FROM tomcatjss-deps AS tomcatjss-runner
+
+# Import JSS packages
+COPY --from=ghcr.io/dogtagpki/jss-dist:latest /root/RPMS /tmp/RPMS/
+
+# Import Tomcat JSS packages
+COPY --from=tomcatjss-dist /root/RPMS /tmp/RPMS/
 
 # Install runtime packages
 RUN dnf localinstall -y /tmp/RPMS/* \


### PR DESCRIPTION
The CI has been modified to store the RPMs in an Alpine-based image and publish it to GH Packages to reduce the size of the distribution.

**Note:** Since this PR depends on [JSS PR #919](https://github.com/dogtagpki/jss/pull/919), currently it uses `edewata/jss-dist`. Once the JSS PR is merged it will be changed to `dogtagpki/jss-dist`.