### PR TITLE
Replace BASE64_MATRIX with BASE64_OS

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -12,9 +12,7 @@ jobs:
     name: Build Test
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
-    container: fedora:${{ matrix.os }}
+    container: ${{ needs.init.outputs.base-image }}
     steps:
     - name: Clone repository
       uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,6 @@ jobs:
     name: Building Tomcat JSS
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -25,7 +23,7 @@ jobs:
         id: cache-buildx
         uses: actions/cache@v3
         with:
-          key: buildx-${{ matrix.os }}-${{ hashFiles('tomcatjss.spec') }}
+          key: buildx-${{ hashFiles('tomcatjss.spec') }}
           path: /tmp/.buildx-cache
 
       - name: Build tomcatjss-deps image
@@ -33,7 +31,7 @@ jobs:
         with:
           context: .
           build-args: |
-            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: tomcatjss-deps
           target: tomcatjss-deps
@@ -45,7 +43,7 @@ jobs:
         with:
           context: .
           build-args: |
-            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: tomcatjss-builder-deps
           target: tomcatjss-builder-deps
@@ -57,7 +55,7 @@ jobs:
         with:
           context: .
           build-args: |
-            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: tomcatjss-builder
           target: tomcatjss-builder
@@ -67,7 +65,7 @@ jobs:
       - name: Store tomcatjss-builder image
         uses: actions/cache@v3
         with:
-          key: tomcatjss-builder-${{ matrix.os }}-${{ github.sha }}
+          key: tomcatjss-builder-${{ github.sha }}
           path: tomcatjss-builder.tar
 
       - name: Build tomcatjss-dist image
@@ -75,7 +73,7 @@ jobs:
         with:
           context: .
           build-args: |
-            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: tomcatjss-dist
           target: tomcatjss-dist
@@ -85,7 +83,7 @@ jobs:
       - name: Store tomcatjss-dist image
         uses: actions/cache@v3
         with:
-          key: tomcatjss-dist-${{ matrix.os }}-${{ github.sha }}
+          key: tomcatjss-dist-${{ github.sha }}
           path: tomcatjss-dist.tar
 
       - name: Build tomcatjss-runner image
@@ -93,7 +91,7 @@ jobs:
         with:
           context: .
           build-args: |
-            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: tomcatjss-runner
           target: tomcatjss-runner
@@ -103,5 +101,5 @@ jobs:
       - name: Store tomcatjss-runner image
         uses: actions/cache@v3
         with:
-          key: tomcatjss-runner-${{ matrix.os }}-${{ github.sha }}
+          key: tomcatjss-runner-${{ github.sha }}
           path: tomcatjss-runner.tar

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -11,14 +11,12 @@ jobs:
     name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Wait for build
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.ref }}
-          check-name: 'Building Tomcat JSS (${{ matrix.os }})'
+          check-name: 'Building Tomcat JSS'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'push'
@@ -27,7 +25,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building Tomcat JSS (${{ matrix.os }})'
+          check-name: 'Building Tomcat JSS'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'pull_request'
@@ -38,8 +36,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/tomcatjss
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -48,7 +44,7 @@ jobs:
       - name: Retrieve tomcatjss-runner image
         uses: actions/cache@v3
         with:
-          key: tomcatjss-runner-${{ matrix.os }}-${{ github.sha }}
+          key: tomcatjss-runner-${{ github.sha }}
           path: tomcatjss-runner.tar
 
       - name: Load tomcatjss-runner image

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -2,15 +2,15 @@ name: Initialization
 on:
   workflow_call:
     secrets:
-      BASE64_MATRIX:
+      BASE64_OS:
         required: false
       BASE64_REPO:
         required: false
       BASE64_DATABASE:
         required: false
     outputs:
-      matrix:
-        value: ${{ jobs.init.outputs.matrix }}
+      base-image:
+        value: ${{ jobs.init.outputs.base-image }}
       repo:
         value: ${{ jobs.init.outputs.repo }}
       db-image:
@@ -21,7 +21,7 @@ jobs:
     name: Initializing workflow
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.init.outputs.matrix }}
+      base-image: ${{ steps.init.outputs.base-image }}
       repo: ${{ steps.init.outputs.repo }}
       db-image: ${{ steps.init.outputs.db-image }}
     steps:
@@ -31,7 +31,7 @@ jobs:
       - name: Initialize workflow
         id: init
         env:
-          BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
+          BASE64_OS: ${{ secrets.BASE64_OS }}
           BASE64_REPO: ${{ secrets.BASE64_REPO }}
           BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
         run: |

--- a/.github/workflows/pki-tests.yml
+++ b/.github/workflows/pki-tests.yml
@@ -12,14 +12,12 @@ jobs:
     name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Wait for build
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.ref }}
-          check-name: 'Building Tomcat JSS (${{ matrix.os }})'
+          check-name: 'Building Tomcat JSS'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'push'
@@ -28,7 +26,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building Tomcat JSS (${{ matrix.os }})'
+          check-name: 'Building Tomcat JSS'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'pull_request'
@@ -40,8 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/tomcatjss
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -49,7 +45,7 @@ jobs:
       - name: Retrieve tomcatjss-runner image
         uses: actions/cache@v3
         with:
-          key: tomcatjss-runner-${{ matrix.os }}-${{ github.sha }}
+          key: tomcatjss-runner-${{ github.sha }}
           path: tomcatjss-runner.tar
 
       - name: Load tomcatjss-runner image
@@ -144,8 +140,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/tomcatjss
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -153,7 +147,7 @@ jobs:
       - name: Retrieve tomcatjss-runner image
         uses: actions/cache@v3
         with:
-          key: tomcatjss-runner-${{ matrix.os }}-${{ github.sha }}
+          key: tomcatjss-runner-${{ github.sha }}
           path: tomcatjss-runner.tar
 
       - name: Load tomcatjss-runner image
@@ -203,6 +197,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-${{ matrix.os }}
+          name: ca
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,8 +19,6 @@ jobs:
     name: Publishing Tomcat JSS
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Log in to the Container registry
         uses: docker/login-action@v2
@@ -32,7 +30,7 @@ jobs:
       - name: Retrieve tomcatjss-dist image
         uses: actions/cache@v3
         with:
-          key: tomcatjss-dist-${{ matrix.os }}-${{ github.sha }}
+          key: tomcatjss-dist-${{ github.sha }}
           path: tomcatjss-dist.tar
 
       - name: Publish tomcatjss-dist image
@@ -44,7 +42,7 @@ jobs:
       - name: Retrieve tomcatjss-runner image
         uses: actions/cache@v3
         with:
-          key: tomcatjss-runner-${{ matrix.os }}-${{ github.sha }}
+          key: tomcatjss-runner-${{ github.sha }}
           path: tomcatjss-runner.tar
 
       - name: Publish tomcatjss-runner image

--- a/.github/workflows/sonarcloud-pull.yml
+++ b/.github/workflows/sonarcloud-pull.yml
@@ -77,8 +77,6 @@ jobs:
     name: Building TomcatJSS
     needs: [init, retrieve-pr]
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone the repository
         uses: actions/checkout@v3
@@ -102,7 +100,7 @@ jobs:
         with:
           context: .
           build-args: |
-            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: tomcatjss-runner
           target: tomcatjss-runner
@@ -111,7 +109,7 @@ jobs:
       - name: Store runner image
         uses: actions/cache@v3
         with:
-          key: sonar-runner-${{ matrix.os }}-${{ github.event.workflow_run.id }}
+          key: sonar-runner-${{ github.event.workflow_run.id }}
           path: sonar-runner.tar
 
   sonarcloud:
@@ -121,13 +119,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/ldapjdk
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: sonar-runner-${{ matrix.os }}-${{ github.event.workflow_run.id }}
+          key: sonar-runner-${{ github.event.workflow_run.id }}
           path: sonar-runner.tar
 
       - name: Load runner image

--- a/tests/bin/init-workflow.sh
+++ b/tests/bin/init-workflow.sh
@@ -1,14 +1,15 @@
 #!/bin/bash -e
 
-if [ "$BASE64_MATRIX" == "" ]
+if [ "$BASE64_OS" != "" ]
 then
-    MATRIX="{\"os\":[\"latest\"]}"
+    OS_VERSION=$(echo "$BASE64_OS" | base64 -d)
 else
-    MATRIX=$(echo "$BASE64_MATRIX" | base64 -d)
+    OS_VERSION=latest
 fi
 
-echo "MATRIX: $MATRIX"
-echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+BASE_IMAGE=registry.fedoraproject.org/fedora:$OS_VERSION
+echo "BASE_IMAGE: $BASE_IMAGE"
+echo "base-image=$BASE_IMAGE" >> $GITHUB_OUTPUT
 
 if [ "$BASE64_REPO" == "" ]
 then


### PR DESCRIPTION
Previously the `BASE64_MATRIX` parameter provided a mechanism to test against multiple Fedora versions at once. However, since the test resources are limited and only one of the versions is eventually published, the parameter has been replaced with a new `BASE64_OS` parameter which only supports a single Fedora version.

https://github.com/dogtagpki/pki/wiki/Configuring-Test-OS