### PR TITLE
Publish to GitHub Maven registry

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -41,8 +41,8 @@ jobs:
       run: |
         mvn install:install-file \
             -Dfile=/usr/lib/java/jss.jar \
-            -DgroupId=org.dogtagpki \
-            -DartifactId=jss \
+            -DgroupId=org.dogtagpki.jss \
+            -DartifactId=jss-base \
             -Dversion=5.4.0-SNAPSHOT \
             -Dpackaging=jar \
             -DgeneratePom=true
@@ -54,7 +54,7 @@ jobs:
     - name: Compare tomcatjss.jar
       run: |
         jar tvf ~/build/tomcatjss/jars/tomcatjss.jar | awk '{print $8;}' | sort | tee ant.out
-        jar tvf main/target/tomcatjss-main-8.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort > maven.out
+        jar tvf main/target/tomcatjss-main-8.4.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort > maven.out
         diff ant.out maven.out
 
     - name: Build Tomcat JSS RPMS with Ant

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,12 +15,47 @@ jobs:
     secrets: inherit
     if: vars.REGISTRY != ''
 
-  build:
-    name: Waiting for build
+  publish-maven:
+    name: Publishing Maven artifacts
     needs: init
     runs-on: ubuntu-latest
     steps:
-      - name: Wait for build
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - name: Check settings.xml
+        run: |
+          cat ~/.m2/settings.xml
+
+      - name: Update pom.xml
+        run: |
+          sed -i \
+              -e "s/OWNER/$NAMESPACE/g" \
+              -e "s/REPOSITORY/tomcatjss/g" \
+              pom.xml
+          cat pom.xml
+
+      - name: Publish Maven artifacts
+        run: |
+          mvn \
+              --batch-mode \
+              --update-snapshots \
+              deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  wait-for-images:
+    name: Waiting for container images
+    needs: init
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for container images
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.ref }}
@@ -28,9 +63,9 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
 
-  publish:
-    name: Publishing Tomcat JSS
-    needs: [init, build]
+  publish-images:
+    name: Publishing container images
+    needs: [init, wait-for-images]
     runs-on: ubuntu-latest
     steps:
       - name: Log in to GitHub Container Registry

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build
 dist
 target/
+.flattened-pom.xml

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,9 +4,15 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.dogtagpki</groupId>
+
+    <parent>
+        <groupId>org.dogtagpki.tomcatjss</groupId>
+        <artifactId>tomcatjss-parent</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>tomcatjss-core</artifactId>
-    <version>8.3.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
     <dependencies>
 
@@ -29,8 +35,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.dogtagpki</groupId>
-            <artifactId>jss</artifactId>
+            <groupId>org.dogtagpki.jss</groupId>
+            <artifactId>jss-base</artifactId>
             <version>5.4.0-SNAPSHOT</version>
         </dependency>
 

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -4,22 +4,28 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.dogtagpki</groupId>
+
+    <parent>
+        <groupId>org.dogtagpki.tomcatjss</groupId>
+        <artifactId>tomcatjss-parent</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>tomcatjss-main</artifactId>
-    <version>8.3.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
     <dependencies>
 
         <dependency>
-            <groupId>org.dogtagpki</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>tomcatjss-core</artifactId>
-            <version>8.3.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.dogtagpki</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>tomcatjss-tomcat-9.0</artifactId>
-            <version>8.3.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
     </dependencies>
@@ -40,6 +46,7 @@
                             <artifactSet>
                                 <excludes>
                                     <exclude>org.slf4j:slf4j-api</exclude>
+                                    <exclude>org.slf4j:slf4j-jdk14</exclude>
                                     <exclude>org.apache.commons:commons-lang3</exclude>
                                     <exclude>org.apache.tomcat:tomcat-catalina</exclude>
                                     <exclude>org.apache.tomcat:tomcat-servlet-api</exclude>
@@ -53,7 +60,7 @@
                                     <exclude>org.apache.tomcat:tomcat-util</exclude>
                                     <exclude>org.apache.tomcat:tomcat-util-scan</exclude>
                                     <exclude>org.apache.tomcat:tomcat-jaspic-api</exclude>
-                                    <exclude>org.dogtagpki:jss</exclude>
+                                    <exclude>org.dogtagpki.jss:jss-base</exclude>
                                 </excludes>
                             </artifactSet>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -4,15 +4,68 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.dogtagpki</groupId>
-    <artifactId>tomcatjss</artifactId>
-    <version>8.3.0-SNAPSHOT</version>
+    <groupId>org.dogtagpki.tomcatjss</groupId>
+    <artifactId>tomcatjss-parent</artifactId>
+    <version>${revision}</version>
     <packaging>pom</packaging>
+
+    <properties>
+        <revision>8.4.0-SNAPSHOT</revision>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
     <modules>
         <module>core</module>
         <module>tomcat-9.0</module>
         <module>main</module>
     </modules>
+
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>flatten-maven-plugin</artifactId>
+          <version>1.1.0</version>
+          <configuration>
+            <updatePomFile>true</updatePomFile>
+            <flattenMode>resolveCiFriendliesOnly</flattenMode>
+          </configuration>
+          <executions>
+            <execution>
+              <id>flatten</id>
+              <phase>process-resources</phase>
+              <goals>
+                <goal>flatten</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>flatten.clean</id>
+              <phase>clean</phase>
+              <goals>
+                <goal>clean</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/OWNER/*</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/OWNER/REPOSITORY</url>
+        </repository>
+    </distributionManagement>
 
 </project>

--- a/tomcat-9.0/pom.xml
+++ b/tomcat-9.0/pom.xml
@@ -4,9 +4,15 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.dogtagpki</groupId>
+
+    <parent>
+        <groupId>org.dogtagpki.tomcatjss</groupId>
+        <artifactId>tomcatjss-parent</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>tomcatjss-tomcat-9.0</artifactId>
-    <version>8.3.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
     <dependencies>
 
@@ -17,15 +23,15 @@
         </dependency>
 
         <dependency>
-            <groupId>org.dogtagpki</groupId>
-            <artifactId>jss</artifactId>
+            <groupId>org.dogtagpki.jss</groupId>
+            <artifactId>jss-base</artifactId>
             <version>5.4.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
-            <groupId>org.dogtagpki</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>tomcatjss-core</artifactId>
-            <version>8.3.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
A new job has been added to build Tomcat JSS with Maven and publish the artifacts to GitHub Maven registry. The group ID and artifact ID have been renamed to follow a more commonly used pattern.

Once it's merged, the packages will look like the following:
https://github.com/edewata?tab=packages&repo_name=tomcatjss
