### PR TITLE
Update build tests to account for latest version bump

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -43,7 +43,7 @@ jobs:
             -Dfile=/usr/lib/java/jss.jar \
             -DgroupId=org.dogtagpki.jss \
             -DartifactId=jss-base \
-            -Dversion=5.4.0-SNAPSHOT \
+            -Dversion=5.5.0-SNAPSHOT \
             -Dpackaging=jar \
             -DgeneratePom=true
 
@@ -54,7 +54,7 @@ jobs:
     - name: Compare tomcatjss.jar
       run: |
         jar tvf ~/build/tomcatjss/jars/tomcatjss.jar | awk '{print $8;}' | sort | tee ant.out
-        jar tvf main/target/tomcatjss-main-8.4.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort > maven.out
+        jar tvf main/target/tomcatjss-main-8.5.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort > maven.out
         diff ant.out maven.out
 
     - name: Build Tomcat JSS RPMS with Ant

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.dogtagpki.jss</groupId>
             <artifactId>jss-base</artifactId>
-            <version>5.4.0-SNAPSHOT</version>
+            <version>5.5.0-SNAPSHOT</version>
         </dependency>
 
     </dependencies>

--- a/tomcat-9.0/pom.xml
+++ b/tomcat-9.0/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.dogtagpki.jss</groupId>
             <artifactId>jss-base</artifactId>
-            <version>5.4.0-SNAPSHOT</version>
+            <version>5.5.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Fixes the broken build tests. We probably need to figure out a way to do this without hard-coding the versions.