### PR TITLE
Build RPM with Maven

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -3,6 +3,7 @@ name: Build Tests
 on: [push, pull_request]
 
 env:
+  NAMESPACE: ${{ vars.REGISTRY_NAMESPACE || github.repository_owner }}
   COPR_REPO: ${{ vars.COPR_REPO || '@pki/master' }}
 
 jobs:
@@ -36,6 +37,8 @@ jobs:
 
     - name: Build Tomcat JSS with Ant
       run: |
+        # Ant build needs the full Tomcat package
+        dnf install -y tomcat
         ./build.sh
 
     - name: Install JSS into Maven repo
@@ -55,10 +58,10 @@ jobs:
     - name: Compare tomcatjss.jar
       run: |
         jar tvf ~/build/tomcatjss/jars/tomcatjss.jar | awk '{print $8;}' | sort | tee ant.out
-        jar tvf main/target/tomcatjss-main-8.5.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort > maven.out
+        jar tvf main/target/tomcatjss.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort > maven.out
         diff ant.out maven.out
 
-    - name: Build Tomcat JSS RPMS with Ant
+    - name: Build Tomcat JSS RPMS with Maven
       run: |
         ./build.sh --work-dir=build rpm
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -35,6 +35,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-coyote</artifactId>
+            <version>9.0.50</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.dogtagpki.jss</groupId>
             <artifactId>jss-base</artifactId>
             <version>5.5.0-SNAPSHOT</version>

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -63,6 +63,7 @@
                                     <exclude>org.dogtagpki.jss:jss-base</exclude>
                                 </excludes>
                             </artifactSet>
+                            <finalName>tomcatjss</finalName>
                         </configuration>
                     </execution>
                 </executions>

--- a/tomcat-9.0/pom.xml
+++ b/tomcat-9.0/pom.xml
@@ -18,7 +18,7 @@
 
         <dependency>
             <groupId>org.apache.tomcat</groupId>
-            <artifactId>tomcat-catalina</artifactId>
+            <artifactId>tomcat-juli</artifactId>
             <version>9.0.50</version>
         </dependency>
 

--- a/tomcatjss.spec
+++ b/tomcatjss.spec
@@ -65,23 +65,22 @@ Source:           https://github.com/dogtagpki/tomcatjss/archive/v%{version}%{?p
 
 # Java
 BuildRequires:    ant
-BuildRequires:    apache-commons-lang3
 BuildRequires:    %{java_devel}
-BuildRequires:    jpackage-utils >= 0:1.7.5-15
+BuildRequires:    maven-local
+BuildRequires:    mvn(org.apache.maven.plugins:maven-shade-plugin)
+BuildRequires:    mvn(org.apache.commons:commons-lang3)
 
 # SLF4J
-BuildRequires:    slf4j
-BuildRequires:    slf4j-jdk14
-
-# JSS
-BuildRequires:    jss >= 5.4
+BuildRequires:    mvn(org.slf4j:slf4j-api)
+BuildRequires:    mvn(org.slf4j:slf4j-jdk14)
 
 # Tomcat
-%if 0%{?rhel} && ! 0%{?eln}
-BuildRequires:    pki-servlet-engine >= 1:9.0.7
-%else
-BuildRequires:    tomcat >= 1:9.0.7
-%endif
+BuildRequires:    mvn(org.apache.tomcat:tomcat-catalina)
+BuildRequires:    mvn(org.apache.tomcat:tomcat-coyote)
+BuildRequires:    mvn(org.apache.tomcat:tomcat-juli)
+
+# JSS
+BuildRequires:    mvn(org.dogtagpki.jss:jss-base) >= 5.5.0
 
 %description
 JSS Connector for Apache Tomcat, installed via the tomcatjss package,
@@ -96,23 +95,20 @@ Services (NSS).
 Summary:          JSS Connector for Apache Tomcat
 
 # Java
-Requires:         apache-commons-lang3
 Requires:         %{java_headless}
-Requires:         jpackage-utils >= 0:1.7.5-15
+Requires:         mvn(org.apache.commons:commons-lang3)
 
 # SLF4J
-Requires:         slf4j
-Requires:         slf4j-jdk14
-
-# JSS
-Requires:         jss >= 5.4
+Requires:         mvn(org.slf4j:slf4j-api)
+Requires:         mvn(org.slf4j:slf4j-jdk14)
 
 # Tomcat
-%if 0%{?rhel} && ! 0%{?eln}
-Requires:         pki-servlet-engine >= 1:9.0.7
-%else
-Requires:         tomcat >= 1:9.0.7
-%endif
+Requires:         mvn(org.apache.tomcat:tomcat-catalina)
+Requires:         mvn(org.apache.tomcat:tomcat-coyote)
+Requires:         mvn(org.apache.tomcat:tomcat-juli)
+
+# JSS
+Requires:         mvn(org.dogtagpki.jss:jss-base) >= 5.5.0
 
 Obsoletes:        tomcatjss < %{version}-%{release}
 Provides:         tomcatjss = %{version}-%{release}
@@ -146,38 +142,28 @@ Services (NSS).
 
 export JAVA_HOME=%{java_home}
 
-./build.sh \
-    %{?_verbose:-v} \
-    --name=%{product_id} \
-    --work-dir=%{_vpath_builddir} \
-    --version=%{version} \
-    --jni-dir=%{_jnidir} \
-    dist
+# flatten-maven-plugin is not available in RPM
+%pom_remove_plugin org.codehaus.mojo:flatten-maven-plugin
+
+# build without Javadoc
+%mvn_build -j
 
 ################################################################################
 %install
 ################################################################################
 
-./build.sh \
-    %{?_verbose:-v} \
-    --name=%{product_id} \
-    --work-dir=%{_vpath_builddir} \
-    --version=%{version} \
-    --java-dir=%{_javadir} \
-    --doc-dir=%{_docdir} \
-    --install-dir=%{buildroot} \
-    install
+%mvn_install
+
+install -p main/target/tomcatjss.jar %{buildroot}%{_javadir}/tomcatjss.jar
 
 ################################################################################
-%files -n %{product_id}
+%files -n %{product_id} -f .mfiles
 ################################################################################
 
 %license LICENSE
-
-%defattr(-,root,root)
 %doc README
 %doc LICENSE
-%{_javadir}/*
+%{_javadir}/tomcatjss.jar
 
 ################################################################################
 %changelog


### PR DESCRIPTION
The RPM spec file has been modified to use Maven dependencies and to build the code with Maven. The support for Ant build may be dropped separately later.