### PR TITLE
Push IPs address to SSLEngine session

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -105,6 +105,7 @@
   <property name="catalina.jar" value="${tomcat.home}/lib/catalina.jar" />
   <property name="tomcat-api.jar" value="${tomcat.home}/lib/tomcat-api.jar" />
   <property name="tomcat-coyote.jar" value="${tomcat.home}/lib/tomcat-coyote.jar" />
+  <property name="tomcat-util.jar" value="${tomcat.home}/lib/tomcat-util.jar" />
   <property name="tomcat-juli.jar" value="${tomcat.home}/bin/tomcat-juli.jar" />
 
   <property name="jss.home" value="${jnidir}" />
@@ -121,6 +122,7 @@
     <pathelement location="${catalina.jar}"/>
     <pathelement location="${tomcat-api.jar}"/>
     <pathelement location="${tomcat-coyote.jar}"/>
+    <pathelement location="${tomcat-util.jar}"/>
     <pathelement location="${tomcat-juli.jar}"/>
     <pathelement location="${commons-logging.jar}"/>
     <pathelement location="${commons-lang3.jar}"/>

--- a/core/src/main/java/org/dogtagpki/tomcat/JSSNioEndpoint.java
+++ b/core/src/main/java/org/dogtagpki/tomcat/JSSNioEndpoint.java
@@ -1,0 +1,90 @@
+package org.dogtagpki.tomcat;
+
+
+import java.nio.channels.SocketChannel;
+import java.util.List;
+
+import javax.net.ssl.SSLEngine;
+
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+import org.apache.tomcat.util.ExceptionUtils;
+import org.apache.tomcat.util.net.NioChannel;
+import org.apache.tomcat.util.net.NioEndpoint;
+import org.apache.tomcat.util.net.SocketBufferHandler;
+import org.apache.tomcat.util.net.openssl.ciphers.Cipher;
+
+public class JSSNioEndpoint extends NioEndpoint {
+
+    private static final Log log = LogFactory.getLog(NioEndpoint.class);
+    /**
+     * Code in the following method is almost identical of that available in the base
+     * class {@link org.apache.tomcat.util.net.NioEndpoint#setSocketOptions(SocketChannel) from tomcat.
+     * <p>
+     * The only difference is the instantiation of the JSSSecureNioChannel class instead of the tomcat
+     * provided SecureNioChannel class. This is needed because the channel class is hard-coded in the
+     * base class method.
+     *
+     * @see org.apache.tomcat.util.net.NioEndpoint#setSocketOptions(SocketChannel socket)
+     */
+
+    @Override
+    protected boolean setSocketOptions(SocketChannel socket) {
+        NioSocketWrapper socketWrapper = null;
+        try {
+            // Allocate channel and wrapper
+            NioChannel channel = null;
+            if (getNioChannels() != null) {
+                channel = getNioChannels().pop();
+            }
+            if (channel == null) {
+                SocketBufferHandler bufhandler = new SocketBufferHandler(
+                        socketProperties.getAppReadBufSize(),
+                        socketProperties.getAppWriteBufSize(),
+                        socketProperties.getDirectBuffer());
+                if (isSSLEnabled()) {
+// This is the change from the code in the base class
+                    channel = new JSSSecureNioChannel(bufhandler, this);
+// End of difference
+                } else {
+                    channel = new NioChannel(bufhandler);
+                }
+            }
+            NioSocketWrapper newWrapper = new NioSocketWrapper(channel, this);
+            channel.reset(socket, newWrapper);
+            connections.put(socket, newWrapper);
+            socketWrapper = newWrapper;
+
+            // Set socket properties
+            // Disable blocking, polling will be used
+            socket.configureBlocking(false);
+            if (getUnixDomainSocketPath() == null) {
+                socketProperties.setProperties(socket.socket());
+            }
+
+            socketWrapper.setReadTimeout(getConnectionTimeout());
+            socketWrapper.setWriteTimeout(getConnectionTimeout());
+            socketWrapper.setKeepAliveLeft(JSSNioEndpoint.this.getMaxKeepAliveRequests());
+            getPoller().register(socketWrapper);
+            return true;
+        } catch (Throwable t) {
+            ExceptionUtils.handleThrowable(t);
+            try {
+                log.error(sm.getString("endpoint.socketOptionsError"), t);
+            } catch (Throwable tt) {
+                ExceptionUtils.handleThrowable(tt);
+            }
+            if (socketWrapper == null) {
+                destroySocket(socket);
+            }
+        }
+        // Tell to close the socket if needed
+        return false;
+
+    }
+    @Override
+    protected SSLEngine createSSLEngine(String arg0, List<Cipher> arg1, List<String> arg2) {
+        return super.createSSLEngine(arg0, arg1, arg2);
+    }
+
+}

--- a/core/src/main/java/org/dogtagpki/tomcat/JSSSecureNioChannel.java
+++ b/core/src/main/java/org/dogtagpki/tomcat/JSSSecureNioChannel.java
@@ -1,0 +1,289 @@
+package org.dogtagpki.tomcat;
+
+import java.io.IOException;
+import java.nio.channels.SelectionKey;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.net.ssl.SSLEngineResult;
+import javax.net.ssl.SSLEngineResult.HandshakeStatus;
+import javax.net.ssl.SSLEngineResult.Status;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSession;
+
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+import org.apache.tomcat.util.buf.ByteBufferUtils;
+import org.apache.tomcat.util.compat.JreCompat;
+import org.apache.tomcat.util.net.NioEndpoint;
+import org.apache.tomcat.util.net.SSLSupport;
+import org.apache.tomcat.util.net.SSLUtil;
+import org.apache.tomcat.util.net.SecureNioChannel;
+import org.apache.tomcat.util.net.SocketBufferHandler;
+import org.apache.tomcat.util.net.TLSClientHelloExtractor;
+import org.apache.tomcat.util.net.TLSClientHelloExtractor.ExtractorResult;
+import org.apache.tomcat.util.net.openssl.ciphers.Cipher;
+import org.apache.tomcat.util.res.StringManager;
+import org.mozilla.jss.ssl.javax.JSSSession;
+/**
+ * Implementation of a secure socket channel
+ * <p>
+ * Code in the following methods are almost identical of that available in the base
+ * class {@link org.apache.tomcat.util.net.SecureNioChannel from tomcat.
+ * <p>
+ * The only difference is the registration of local and remote IP in the SSL engine session.
+ * These IPs are required for audit purpose but the tomcat implementation does not provide
+ * such information to the engine, since they are not needed for Java SSL engine specification.
+ * <p>
+ * The SSL engine is created in the private method {@link JSSSecureNioChannel#processSNI()} so
+ * the calling methods have been duplicated in order to work properly.
+ *
+ * @see org.apache.tomcat.util.net.SecureNioChannel
+ */
+
+public class JSSSecureNioChannel extends SecureNioChannel {
+
+    private static final Log log = LogFactory.getLog(JSSSecureNioChannel.class);
+    private static final StringManager sm = StringManager.getManager(JSSSecureNioChannel.class);
+
+    private final JSSNioEndpoint endpoint;
+
+    private final Map<String,List<String>> additionalTlsAttributes = new HashMap<>();
+
+    public JSSSecureNioChannel(SocketBufferHandler bufHandler, NioEndpoint endpoint) {
+        super(bufHandler, endpoint);
+        this.endpoint = (JSSNioEndpoint) endpoint;
+    }
+
+
+    /**
+     * Performs SSL handshake, non blocking, but performs NEED_TASK on the same
+     * thread. Hence, you should never call this method using your Acceptor
+     * thread, as you would slow down your system significantly. If the return
+     * value from this method is positive, the selection key should be
+     * registered interestOps given by the return value.
+     *
+     * @param read boolean - true if the underlying channel is readable
+     * @param write boolean - true if the underlying channel is writable
+     *
+     * @return 0 if hand shake is complete, -1 if an error (other than an
+     *         IOException) occurred, otherwise it returns a SelectionKey
+     *         interestOps value
+     *
+     * @throws IOException If an I/O error occurs during the handshake or if the
+     *                     handshake fails during wrapping or unwrapping
+     */
+    @Override
+    public int handshake(boolean read, boolean write) throws IOException {
+        if (handshakeComplete) {
+            return 0; //we have done our initial handshake
+        }
+
+        if (!sniComplete) {
+            int sniResult = processSNI();
+            if (sniResult == 0) {
+                sniComplete = true;
+            } else {
+                return sniResult;
+            }
+        }
+
+        if (!flush(netOutBuffer)) {
+            return SelectionKey.OP_WRITE; //we still have data to write
+        }
+
+        SSLEngineResult handshake = null;
+
+        while (!handshakeComplete) {
+            switch (handshakeStatus) {
+                case NOT_HANDSHAKING:
+                    //should never happen
+                    throw new IOException(sm.getString("channel.nio.ssl.notHandshaking"));
+                case FINISHED:
+                    if (endpoint.hasNegotiableProtocols()) {
+                        if (sslEngine instanceof SSLUtil.ProtocolInfo) {
+                            socketWrapper.setNegotiatedProtocol(
+                                    ((SSLUtil.ProtocolInfo) sslEngine).getNegotiatedProtocol());
+                        } else if (JreCompat.isAlpnSupported()) {
+                            socketWrapper.setNegotiatedProtocol(
+                                    JreCompat.getInstance().getApplicationProtocol(sslEngine));
+                        }
+                    }
+                    //we are complete if we have delivered the last package
+                    handshakeComplete = !netOutBuffer.hasRemaining();
+                    //return 0 if we are complete, otherwise we still have data to write
+                    return handshakeComplete ? 0 : SelectionKey.OP_WRITE;
+                case NEED_WRAP:
+                    //perform the wrap function
+                    try {
+                        handshake = handshakeWrap(write);
+                    } catch (SSLException e) {
+                        handshake = handshakeWrap(write);
+                        throw e;
+                    }
+                    if (handshake.getStatus() == Status.OK) {
+                        if (handshakeStatus == HandshakeStatus.NEED_TASK) {
+                            handshakeStatus = tasks();
+                        }
+                    } else if (handshake.getStatus() == Status.CLOSED) {
+                        flush(netOutBuffer);
+                        return -1;
+                    } else {
+                        //wrap should always work with our buffers
+                        throw new IOException(sm.getString("channel.nio.ssl.unexpectedStatusDuringWrap", handshake.getStatus()));
+                    }
+                    if (handshakeStatus != HandshakeStatus.NEED_UNWRAP || (!flush(netOutBuffer))) {
+                        //should actually return OP_READ if we have NEED_UNWRAP
+                        return SelectionKey.OP_WRITE;
+                    }
+                    //fall down to NEED_UNWRAP on the same call, will result in a
+                    //BUFFER_UNDERFLOW if it needs data
+                //$FALL-THROUGH$
+                case NEED_UNWRAP:
+                    //perform the unwrap function
+                    handshake = handshakeUnwrap(read);
+                    if (handshake.getStatus() == Status.OK) {
+                        if (handshakeStatus == HandshakeStatus.NEED_TASK) {
+                            handshakeStatus = tasks();
+                        }
+                    } else if ( handshake.getStatus() == Status.BUFFER_UNDERFLOW ){
+                        //read more data, reregister for OP_READ
+                        return SelectionKey.OP_READ;
+                    } else {
+                        throw new IOException(sm.getString("channel.nio.ssl.unexpectedStatusDuringWrap", handshake.getStatus()));
+                    }
+                    break;
+                case NEED_TASK:
+                    handshakeStatus = tasks();
+                    break;
+                default:
+                    throw new IllegalStateException(sm.getString("channel.nio.ssl.invalidStatus", handshakeStatus));
+            }
+        }
+        // Handshake is complete if this point is reached
+        return 0;
+    }
+
+
+    /*
+     * Peeks at the initial network bytes to determine if the SNI extension is
+     * present and, if it is, what host name has been requested. Based on the
+     * provided host name, configure the SSLEngine for this connection.
+     *
+     * @return 0 if SNI processing is complete, -1 if an error (other than an
+     *         IOException) occurred, otherwise it returns a SelectionKey
+     *         interestOps value
+     *
+     * @throws IOException If an I/O error occurs during the SNI processing
+     */
+    private int processSNI() throws IOException {
+        // Read some data into the network input buffer so we can peek at it.
+        int bytesRead = sc.read(netInBuffer);
+        if (bytesRead == -1) {
+            // Reached end of stream before SNI could be processed.
+            return -1;
+        }
+        TLSClientHelloExtractor extractor = new TLSClientHelloExtractor(netInBuffer);
+
+        while (extractor.getResult() == ExtractorResult.UNDERFLOW &&
+                netInBuffer.capacity() < endpoint.getSniParseLimit()) {
+            // extractor needed more data to process but netInBuffer was full so
+            // expand the buffer and read some more data.
+            int newLimit = Math.min(netInBuffer.capacity() * 2, endpoint.getSniParseLimit());
+            log.info(sm.getString("channel.nio.ssl.expandNetInBuffer",
+                    Integer.toString(newLimit)));
+
+            netInBuffer = ByteBufferUtils.expand(netInBuffer, newLimit);
+            sc.read(netInBuffer);
+            extractor = new TLSClientHelloExtractor(netInBuffer);
+        }
+
+        String hostName = null;
+        List<Cipher> clientRequestedCiphers = null;
+        List<String> clientRequestedApplicationProtocols = null;
+        switch (extractor.getResult()) {
+        case COMPLETE:
+            hostName = extractor.getSNIValue();
+            clientRequestedApplicationProtocols =
+                    extractor.getClientRequestedApplicationProtocols();
+            //$FALL-THROUGH$ to set the client requested ciphers
+        case NOT_PRESENT:
+            clientRequestedCiphers = extractor.getClientRequestedCiphers();
+            break;
+        case NEED_READ:
+            return SelectionKey.OP_READ;
+        case UNDERFLOW:
+            // Unable to buffer enough data to read SNI extension data
+            if (log.isDebugEnabled()) {
+                log.debug(sm.getString("channel.nio.ssl.sniDefault"));
+            }
+            hostName = endpoint.getDefaultSSLHostConfigName();
+            clientRequestedCiphers = Collections.emptyList();
+            break;
+        case NON_SECURE:
+            netOutBuffer.clear();
+            netOutBuffer.put(TLSClientHelloExtractor.USE_TLS_RESPONSE);
+            netOutBuffer.flip();
+            flushOutbound();
+            throw new IOException(sm.getString("channel.nio.ssl.foundHttp"));
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug(sm.getString("channel.nio.ssl.sniHostName", sc, hostName));
+        }
+
+        sslEngine = endpoint.createSSLEngine(hostName, clientRequestedCiphers,
+                clientRequestedApplicationProtocols);
+
+// This is the change from the code in the base class
+        JSSSession jsession = (JSSSession) sslEngine.getSession();
+        jsession.setLocalAddr(socketWrapper.getLocalAddr());
+        jsession.setRemoteAddr(socketWrapper.getRemoteAddr());
+// End of difference
+        // Populate additional TLS attributes obtained from the handshake that
+        // aren't available from the session
+        additionalTlsAttributes.put(SSLSupport.REQUESTED_PROTOCOL_VERSIONS_KEY,
+                extractor.getClientRequestedProtocols());
+        additionalTlsAttributes.put(SSLSupport.REQUESTED_CIPHERS_KEY,
+                extractor.getClientRequestedCipherNames());
+
+        // Ensure the application buffers (which have to be created earlier) are
+        // big enough.
+        getBufHandler().expand(sslEngine.getSession().getApplicationBufferSize());
+        if (netOutBuffer.capacity() < sslEngine.getSession().getApplicationBufferSize()) {
+            // Info for now as we may need to increase DEFAULT_NET_BUFFER_SIZE
+            log.info(sm.getString("channel.nio.ssl.expandNetOutBuffer",
+                    Integer.toString(sslEngine.getSession().getApplicationBufferSize())));
+        }
+        netInBuffer = ByteBufferUtils.expand(netInBuffer, sslEngine.getSession().getPacketBufferSize());
+        netOutBuffer = ByteBufferUtils.expand(netOutBuffer, sslEngine.getSession().getPacketBufferSize());
+
+        // Set limit and position to expected values
+        netOutBuffer.position(0);
+        netOutBuffer.limit(0);
+
+        // Initiate handshake
+        sslEngine.beginHandshake();
+        handshakeStatus = sslEngine.getHandshakeStatus();
+
+        return 0;
+    }
+
+
+
+    public SSLSupport getSSLSupport() {
+        if (sslEngine != null) {
+            SSLSession session = sslEngine.getSession();
+            return endpoint.getSslImplementation().getSSLSupport(session, additionalTlsAttributes);
+        }
+        return null;
+    }
+
+    private enum OverflowState {
+        NONE,
+        PROCESSING,
+        DONE;
+    }
+}


### PR DESCRIPTION
**SSLEngine** is by design unaware of the underlying communication channel. In tomcat the communication channel is started by the classes `NioEndpoint` and it is maintained in `SecureNioChannel` which will create the buffer used with the SSLEngine in order to wrap and unwrap the messages.

To allow the audit of TLS messages to include IP addresses of the client and server, the above classed have been extended in order to store the IPs in the SSLEngine session after its creation.


This require the JSS PR [972](https://github.com/dogtagpki/jss/pull/972)