### PR TITLE
Build RPM without maven-shade-plugin

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -55,15 +55,21 @@ jobs:
       run: |
         mvn package
 
-    - name: Compare tomcatjss.jar
+    - name: Compare tomcatjss.jar built by Ant vs. built by Maven
       run: |
         jar tvf ~/build/tomcatjss/jars/tomcatjss.jar | awk '{print $8;}' | sort | tee ant.out
         jar tvf main/target/tomcatjss.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort > maven.out
         diff ant.out maven.out
 
-    - name: Build Tomcat JSS RPMS with Maven
+    - name: Build Tomcat JSS RPMs
       run: |
         ./build.sh --work-dir=build rpm
+        dnf install -y build/RPMS/*.rpm
+
+    - name: Compare tomcatjss.jar built by Maven vs. from RPM
+      run: |
+        jar tvf /usr/share/java/tomcatjss.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort | tee rpm.out
+        diff maven.out rpm.out
 
     - name: Install RPMInspect
       run: |

--- a/tomcatjss.spec
+++ b/tomcatjss.spec
@@ -67,7 +67,10 @@ Source:           https://github.com/dogtagpki/tomcatjss/archive/v%{version}%{?p
 BuildRequires:    ant
 BuildRequires:    %{java_devel}
 BuildRequires:    maven-local
-BuildRequires:    mvn(org.apache.maven.plugins:maven-shade-plugin)
+
+# maven-shade-plugin is not available on CentOS/RHEL
+#BuildRequires:    mvn(org.apache.maven.plugins:maven-shade-plugin)
+
 BuildRequires:    mvn(org.apache.commons:commons-lang3)
 
 # SLF4J
@@ -145,8 +148,21 @@ export JAVA_HOME=%{java_home}
 # flatten-maven-plugin is not available in RPM
 %pom_remove_plugin org.codehaus.mojo:flatten-maven-plugin
 
+# disable main module since maven-shade-plugin is not available on CentOS/RHEL
+%pom_disable_module main
+
 # build without Javadoc
 %mvn_build -j
+
+# merge JAR files into tomcatjss.jar
+mkdir -p main/target/classes
+
+pushd main/target/classes
+jar xvf ../../../core/target/tomcatjss-core-%{version}-SNAPSHOT.jar
+jar xvf ../../../tomcat-9.0/target/tomcatjss-tomcat-9.0-%{version}-SNAPSHOT.jar
+popd
+
+jar cvf main/target/tomcatjss.jar -C main/target/classes .
 
 ################################################################################
 %install


### PR DESCRIPTION
The RPM spec file has been modified to merge the JAR files using the `jar` command since the `maven-shade-plugin` is not available on CentOS/RHEL.

https://copr.fedorainfracloud.org/coprs/edewata/pki/build/6108411/
