### PR TITLE
Use get-current-version action for COPR builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -42,6 +42,9 @@ jobs:
       - fedora-all
       - centos-stream-9-x86_64
       - rhel-9-x86_64
+    actions:
+      get-current-version:
+      - rpmspec -q --qf "%{Version}" --srpm tomcatjss.spec
 
   - job: copr_build
     trigger: commit
@@ -56,4 +59,6 @@ jobs:
       - fedora-all
       - centos-stream-9-x86_64
       - rhel-9-x86_64
-
+    actions:
+      get-current-version:
+      - rpmspec -q --qf "%{Version}" --srpm tomcatjss.spec


### PR DESCRIPTION
Currently Packit auotmagically overwrites the spec version with a version derived from the latest tag when doing PR/commit COPR builds. This causes problems as the tag can contain the alpha/beta phase in addition to the version.

We don't need to do it for the propose_downstream job as the spec is synced from the upstream repo so it will always provide the correct version.