### PR TITLE
Hard-code version number in pom.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 dist
 target/
 .flattened-pom.xml
+*.versionsBackup

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.tomcatjss</groupId>
         <artifactId>tomcatjss-parent</artifactId>
-        <version>${revision}</version>
+        <version>8.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>tomcatjss-core</artifactId>

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.tomcatjss</groupId>
         <artifactId>tomcatjss-parent</artifactId>
-        <version>${revision}</version>
+        <version>8.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>tomcatjss-main</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,10 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.dogtagpki.tomcatjss</groupId>
     <artifactId>tomcatjss-parent</artifactId>
-    <version>${revision}</version>
+    <version>8.5.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>
-        <revision>8.5.0-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/tomcat-9.0/pom.xml
+++ b/tomcat-9.0/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.tomcatjss</groupId>
         <artifactId>tomcatjss-parent</artifactId>
-        <version>${revision}</version>
+        <version>8.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>tomcatjss-tomcat-9.0</artifactId>


### PR DESCRIPTION
Some build systems require hard-coding the version number in `pom.xml`, so the `revision` property has been replaced with the actual version number. Updating the version number can be done with the following commands:

```
$ mvn versions:set -DnewVersion=<version>
$ mvn versions:commit
```

The `.gitignore` has been updated to ignore the backup files created by this command.